### PR TITLE
Update Assembly version to 3.0.0.0

### DIFF
--- a/Filing_Adapter/Properties/AssemblyInfo.cs
+++ b/Filing_Adapter/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("BuroHappold")]
 [assembly: AssemblyProduct("Filing_Adapter")]
-[assembly: AssemblyCopyright("Copyright © BuroHappold 2018")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Filing_Engine/Properties/AssemblyInfo.cs
+++ b/Filing_Engine/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("BuroHappold")]
 [assembly: AssemblyProduct("Filing_Engine")]
-[assembly: AssemblyCopyright("Copyright © BuroHappold 2018")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Filing_Test/Properties/AssemblyInfo.cs
+++ b/Filing_Test/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("BuroHappold")]
 [assembly: AssemblyProduct("Filing_Test")]
-[assembly: AssemblyCopyright("Copyright © BuroHappold 2018")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Filing_oM/Properties/AssemblyInfo.cs
+++ b/Filing_oM/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("BuroHappold")]
 [assembly: AssemblyProduct("Filing_oM")]
-[assembly: AssemblyCopyright("Copyright © BuroHappold 2018")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #21

<!-- Add short description of what has been fixed -->


### Test
<!-- Link to test files to validate the proposed changes -->
Make sure that:
- All the .csproj files in the solution have the properties  `AssemblyFileVersion` to `3.0.0.0` and `AssemblyVersion` to `3.0.0.0`.
- The AssemblyCopyright reads `[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]`

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Update `AssemblyFileVersion` to `3.0.0.0`
- Update `AssemblyVersion` to `3.0.0.0`