### PR TITLE
Automate the toggle of `UseDatasetSerialization`

### DIFF
--- a/File_Adapter/AdapterActions/Push.cs
+++ b/File_Adapter/AdapterActions/Push.cs
@@ -35,6 +35,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.Engine.Base;
 using BH.oM.Base;
+using BH.oM.Data.Library;
 
 namespace BH.Adapter.File
 {
@@ -76,7 +77,7 @@ namespace BH.Adapter.File
 
         public override List<object> Push(IEnumerable<object> objects, string tag = "", PushType pushType = PushType.AdapterDefault, ActionConfig actionConfig = null)
         {
-            PushConfig pushConfig = actionConfig as PushConfig;
+            PushConfig pushConfig = actionConfig as PushConfig == null ? new PushConfig() : actionConfig as PushConfig;
 
             if (string.IsNullOrWhiteSpace(m_defaultFilePath)) // = if we are about to push multiple files/directories
                 if (pushType == PushType.DeleteThenCreate && m_Push_enableDeleteWarning && !pushConfig.DisableWarnings ) 
@@ -155,6 +156,13 @@ namespace BH.Adapter.File
                 string defaultFileName = Path.GetFileName(m_defaultFilePath);
 
                 FSFile file = CreateFSFile(defaultDirectory, defaultFileName, remainder);
+
+                if (remainder.All(o => o is Dataset))
+                {
+                    // Automatically set UseDatasetSerialization to true.
+                    pushConfig.UseDatasetSerialization = true;
+                    pushConfig.BeautifyJson = false;
+                }
 
                 IResource created = Create(file, pushType, pushConfig);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #102

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Try any scenario where a Dataset is must be pushed to file, and then the serialised file must be read.
Push the Dataset without setting any ActionConfig, then read the file as usual.

A script to generate a Dataset file: the usual `File_Adapter-01c-Push a dataset file`
in https://burohappold.sharepoint.com/:f:/s/BHoM/Eqphw7WXhFxLo8jBjH0JDPQBK46Fas9oo6IZoo_MUGFL7g?e=6xFiQR

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->