### PR TITLE
File_Adapter: filter File.Contents that are not Reference Type parameters; null checks

### DIFF
--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -60,7 +60,17 @@ namespace BH.Adapter.File
 
                 if (!pushConfig.UseDatasetSerialization)
                 {
-                    allLines.AddRange(file.Content.Where(c => c != null).Select(obj => obj.ToJson() + ","));
+                    var content = file.Content;
+
+                    foreach (var obj in content)
+                    {
+                        if (obj == null || obj.GetType().IsValueType)
+                            continue;
+
+                        allLines.Add(obj.ToJson() + ",");
+                    }
+
+                    //allLines.AddRange(file.Content.Where(c => c != null && ((c as double?) != null && (c as double?) != 0)).Select(obj => obj.ToJson() + ","));
 
                     // Remove the trailing comma 
                     if (allLines.Count > 0)

--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -62,8 +62,9 @@ namespace BH.Adapter.File
                 {
                     allLines.AddRange(file.Content.Where(c => c != null).Select(obj => obj.ToJson() + ","));
 
-                    // Remove the trailing comma if there is only one element.
-                    allLines[allLines.Count - 1] = allLines[allLines.Count - 1].Remove(allLines[allLines.Count - 1].Length - 1);
+                    // Remove the trailing comma 
+                    if (allLines.Count > 0)
+                        allLines[allLines.Count - 1] = allLines[allLines.Count - 1].Remove(allLines[allLines.Count - 1].Length - 1);
 
                     // Join all between square brackets to make a valid JSON array.
                     json = String.Join(Environment.NewLine, allLines);

--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -70,8 +70,6 @@ namespace BH.Adapter.File
                         allLines.Add(obj.ToJson() + ",");
                     }
 
-                    //allLines.AddRange(file.Content.Where(c => c != null && ((c as double?) != null && (c as double?) != 0)).Select(obj => obj.ToJson() + ","));
-
                     // Remove the trailing comma 
                     if (allLines.Count > 0)
                         allLines[allLines.Count - 1] = allLines[allLines.Count - 1].Remove(allLines[allLines.Count - 1].Length - 1);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #113 
Closes #114 




<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
General reliability improvements on the File_Adapter:
- added null checks
- disallow Value Types

### Additional comments
<!-- As required -->