### PR TITLE
WriteToJsonFile fixed not to crash on empty collections

### DIFF
--- a/File_Engine/Compute/WriteToJsonFile.cs
+++ b/File_Engine/Compute/WriteToJsonFile.cs
@@ -92,6 +92,9 @@ namespace BH.Engine.Adapters.File
         private static string ToJsonArrayWrappingNonObjects(this List<object> objects)
         {
             string json = "";
+            if (objects.Count == 0)
+                return json;
+
             List<string> allLines = new List<string>();
 
             // Parse all objects.


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #136

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FFile%5FToolkit%2F%23137%2DWriteToJsonFileBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->