### PR TITLE
File_Engine: WriteToJsonFile not to crash on empty collections 

### DIFF
--- a/File_Engine/Compute/WriteToJsonFile.cs
+++ b/File_Engine/Compute/WriteToJsonFile.cs
@@ -92,6 +92,9 @@ namespace BH.Engine.Adapters.File
         private static string ToJsonArrayWrappingNonObjects(this List<object> objects)
         {
             string json = "";
+            if (objects.Count == 0)
+                return json;
+
             List<string> allLines = new List<string>();
 
             // Parse all objects.

--- a/File_Engine/Compute/WriteToJsonFile.cs
+++ b/File_Engine/Compute/WriteToJsonFile.cs
@@ -92,8 +92,6 @@ namespace BH.Engine.Adapters.File
         private static string ToJsonArrayWrappingNonObjects(this List<object> objects)
         {
             string json = "";
-            if (objects.Count == 0)
-                return json;
 
             List<string> allLines = new List<string>();
 
@@ -113,11 +111,16 @@ namespace BH.Engine.Adapters.File
                 allLines.Add(toWrite.ToJson() + ",");
             }
 
-            // Remove the trailing comma if there is only one element.
-            allLines[allLines.Count - 1] = allLines[allLines.Count - 1].Remove(allLines[allLines.Count - 1].Length - 1);
+            if (allLines.Any())
+            {
+                // Remove the trailing comma
+                allLines[allLines.Count - 1] = allLines[allLines.Count - 1].Remove(allLines[allLines.Count - 1].Length - 1);
 
-            // Join all between square brackets to make a valid JSON array.
-            json = String.Join(Environment.NewLine, allLines);
+                // Join all lines 
+                json = String.Join(Environment.NewLine, allLines);
+            }
+
+            // Add square brackets to make a valid JSON array.
             json = "[" + json + "]";
 
             return json;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #136

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FFile%5FToolkit%2F%23137%2DWriteToJsonFileBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

Additionally, all File_Toolkit test scripts have been tested on my machine. 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->