### PR TITLE
File_Adapter: filter File.Contents that are not Reference Type parameters; null checks

### DIFF
--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.File
                 if (!pushConfig.UseDatasetSerialization)
                 {
                     var content = file.Content;
-                    
+
                     bool valueTypesFound = false;
 
                     foreach (var obj in content)
@@ -70,6 +70,14 @@ namespace BH.Adapter.File
 
                         if (obj.GetType().IsValueType)
                         {
+                            if (!pushConfig.SkipUnsupportedTypes)
+                            {
+                                BH.Engine.Base.Compute.RecordError($"Invalid type encountered: {obj.GetType().FullName}. " +
+                                    $"Please either remove this from the input objects, or specify a {typeof(PushConfig).FullName} with {nameof(PushConfig.SkipUnsupportedTypes)} set to true.");
+                                
+                                return null;
+                            }
+
                             valueTypesFound = true;
                             continue;
                         }
@@ -78,7 +86,7 @@ namespace BH.Adapter.File
                     }
 
                     if (valueTypesFound)
-                        BH.Engine.Base.Compute.RecordWarning("Attempted to push directly some non-objects (value types, e.g. numbers), which were skipped. Please wrap those in a CustomObject if required.");
+                        BH.Engine.Base.Compute.RecordNote("Attempted to push directly some non-objects (value types, e.g. numbers), which were skipped. Please wrap those in a CustomObject if required.");
 
                     // Remove the trailing comma 
                     if (allLines.Count > 0)

--- a/File_oM/Config/PushConfig.cs
+++ b/File_oM/Config/PushConfig.cs
@@ -40,7 +40,7 @@ namespace BH.oM.Adapters.File
             "\nThis is the current standard for Datasets.")]
         public bool UseDatasetSerialization { get; set; } = false;
 
-        [Description("By default, certain types cannot be pushed to Json as root-level objects, for example numbers." +
+        [Description("By default, certain types cannot be pushed to Json as root-level objects, for example numbers.\n" +
             "Set this option to `true` to allow skipping those types.")]
         public bool SkipUnsupportedTypes { get; set; } = false;
 

--- a/File_oM/Config/PushConfig.cs
+++ b/File_oM/Config/PushConfig.cs
@@ -40,6 +40,10 @@ namespace BH.oM.Adapters.File
             "\nThis is the current standard for Datasets.")]
         public bool UseDatasetSerialization { get; set; } = false;
 
+        [Description("By default, certain types cannot be pushed to Json as root-level objects, for example numbers." +
+            "Set this option to `true` to allow skipping those types.")]
+        public bool SkipUnsupportedTypes { get; set; } = false;
+
         [Description("If true, beautify Json files for web display. Works only if UseDatasetSerialization is set to false.")]
         public bool BeautifyJson { get; set; } = true;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/File_Toolkit/issues/113
Closes https://github.com/BHoM/File_Toolkit/issues/114

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

Test file:
[PushValueTypes.xlsx](https://github.com/BHoM/File_Toolkit/files/13902962/PushValueTypes.xlsx)

It must throw an error if PushConfig's `SkipInvalidTypes` is set to false:

![image](https://github.com/BHoM/File_Toolkit/assets/6352844/45d5a037-ee9a-49bb-bb79-64c1661ec060)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
General reliability improvements on the File_Adapter:
- disallow Value Types
- last comma removal with null check


### Additional comments
<!-- As required -->