### PR TITLE
Fixed trailing comma on creating json lists

### DIFF
--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -63,8 +63,9 @@ namespace BH.Adapter.File
 
                     bool valueTypesFound = false;
 
-                    foreach (var obj in content)
+                    for (int i = 0; i < content.Count; i++)
                     {
+                        object obj = content[i];
                         if (obj == null)
                             continue;
 
@@ -82,7 +83,10 @@ namespace BH.Adapter.File
                             continue;
                         }
 
-                        allLines.Add(obj.ToJson() + ",");
+                        if (i != content.Count)
+                            allLines.Add(obj.ToJson() + ",");
+                        else
+                            allLines.Add(obj.ToJson());
                     }
 
                     if (valueTypesFound)

--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -63,9 +63,8 @@ namespace BH.Adapter.File
 
                     bool valueTypesFound = false;
 
-                    for (int i = 0; i < content.Count; i++)
+                    foreach (var obj in content)
                     {
-                        object obj = content[i];
                         if (obj == null)
                             continue;
 
@@ -83,10 +82,7 @@ namespace BH.Adapter.File
                             continue;
                         }
 
-                        if (i != content.Count)
-                            allLines.Add(obj.ToJson() + ",");
-                        else
-                            allLines.Add(obj.ToJson());
+                        allLines.Add(obj.ToJson());
                     }
 
                     if (valueTypesFound)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #184 

<!-- Add short description of what has been fixed -->
removed adding commas on every line

### Test files
<!-- Link to test files to validate the proposed changes -->
[File_Adapter-extra-Push and Pull appending content 1.zip](https://github.com/BHoM/File_Toolkit/files/14776521/File_Adapter-extra-Push.and.Pull.appending.content.1.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->