### PR TITLE
Create JSON arrays only where more than one object is detected

### DIFF
--- a/File_Adapter/CRUD/Create/CreateJson.cs
+++ b/File_Adapter/CRUD/Create/CreateJson.cs
@@ -63,6 +63,8 @@ namespace BH.Adapter.File
 
                     bool valueTypesFound = false;
 
+                    int objCount = 0;
+
                     foreach (var obj in content)
                     {
                         if (obj == null)
@@ -83,6 +85,7 @@ namespace BH.Adapter.File
                         }
 
                         allLines.Add(obj.ToJson());
+                        objCount++;
                     }
 
                     if (valueTypesFound)
@@ -93,8 +96,10 @@ namespace BH.Adapter.File
                         json = allLines.Aggregate((a, b) => a + "," + Environment.NewLine + b);
 
                     // Join all between square brackets to make a valid JSON array.
-                    json = String.Join(Environment.NewLine, allLines);
-                    json = "[" + json + "]";
+                    //json = String.Join(Environment.NewLine, allLines);
+
+                    if(objCount > 1)
+                        json = "[" + json + "]";
                 }
                 else
                 {


### PR DESCRIPTION
Only wraps outputs in square brackets if there's more than one object being pushed. Also eliminate the step to remove each trailing comma as this produces invalid json arrays.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #193 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Test file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/File_Toolkit/%23193-JsonArray/%23193-JsonAaray.gh?csf=1&web=1&e=b9M6N6)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->