### PR TITLE
Consolidate versions of external dependencies

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.File.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.File.nuspec
@@ -17,6 +17,9 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.3" />
+        <dependency id="Microsoft.CSharp" version="4.7.0" />
+        <dependency id="System.IO.FileSystem.AccessControl" version="5.0.0" />
+        <dependency id="System.Security.AccessControl" version="6.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/File_Adapter/File_Adapter.csproj
+++ b/File_Adapter/File_Adapter.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #216 

 - Update System.IO.FileSystem.AccessControl as the current package version has been deprecated: https://www.nuget.org/packages/System.IO.FileSystem.AccessControl/6.0.0-preview.5.21301.5?_src=template 
 - Switching to 5.0.0 as recommended on the package's page.


### Test files
Usual testing procedure


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->